### PR TITLE
온라인 대여자를 dashboard 에서 무시

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,3 +1,5 @@
+  - 22:00 예약 사용자는 online 대여자이므로 dashboard 에서 skip
+
 v0.3.11    Wed, 11 Nov 2015 15:27:57 +0900
   - 수선화면에서 reload 를 줄이고 dashboard 를 실시간으로 update
   - 포장완료 상태추가

--- a/lib/OpenCloset/Monitor/Controller/Dashboard.pm
+++ b/lib/OpenCloset/Monitor/Controller/Dashboard.pm
@@ -28,6 +28,10 @@ sub index {
 
     my ( @visit, @measure, @select, @undress, @repair, @boxing, @payment );
     while ( my $order = $rs->next ) {
+        ## 임시로 skip, 22:00 는 온라인 대여자
+        my $booking_date = $order->booking->date;
+        next if $booking_date->hour == '22';
+
         my $status_id = $order->status_id;
         use experimental qw/ smartmatch /;
         given ($status_id) {

--- a/public/assets/coffee/index.coffee
+++ b/public/assets/coffee/index.coffee
@@ -90,6 +90,9 @@ class NotificationRow extends Backbone.View
 
     return @ unless @model.get 'desc'
 
+    ## 임시로 skip, 22:00 는 온라인 대여자
+    return @ if @model.get 'booking_date' is '22:00'
+
     ## 의류준비 - 탈의의 상태가 반복되는 사용자는 알람을 끈다
     _from = if from > 19 and from < 40 then 20 else parseInt(from)
     _to   = if to > 19 and to < 40 then 20 else parseInt(to)


### PR DESCRIPTION
#70 온라인 대여자의 상태는 상황판에 표시될 필요가 없기 때문에 알람이 울리지 않도록 합니다.

임시방편일뿐입니다.
궁극적으로는 주문서에 online, offline flag 를 두고 해결해야 하겠습니다.